### PR TITLE
add sotm 2026

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,17 @@
   </head>
   <body>
     <div class="event">
+      <a href="https://wiki.openstreetmap.org/wiki/State_of_the_Map_2026">
+        <img src="sotm.png" width="200px" />
+        <div class="description">
+          <h1>State of the Map 2026</h1>
+          <h2>Paris, France &amp; Online</h2>
+          <h3>28th to 30th August 2026</h3>
+        </div>
+      </a>
+    </div>
+    <hr />
+    <div class="event">
       <a href="https://2025.stateofthemap.org/">
         <img src="sotm2025.png" width="200px" />
         <div class="description">
@@ -15,7 +26,6 @@
         </div>
       </a>
     </div>
-    <hr />
     <div class="event">
       <a href="https://2024.stateofthemap.org/">
         <img src="sotm2024.svg" width="200px" />


### PR DESCRIPTION
somewhat temporary for now:
* with link to osm wiki [page](https://wiki.openstreetmap.org/wiki/State_of_the_Map_2026) for now until the website is launched
* with generic sotm logo for now until a logo has been chosen