### PR TITLE
add links to sotm 2024, 2025 and 2026 to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Replace `<branch>` with the name of the branch you want to clone.
 
 ## Other State of the Map website repositories
 
+* https://github.com/openstreetmap/stateofthemap-2026
+* https://github.com/openstreetmap/stateofthemap-2025
+* https://github.com/openstreetmap/stateofthemap-2024
 * https://github.com/openstreetmap/stateofthemap-2022
 * https://github.com/openstreetmap/stateofthemap-2021
 * https://github.com/openstreetmap/stateofthemap-2020


### PR DESCRIPTION
The 2026 repo is still a placeholder at the moment, but will be filled with a first version sometime soon.